### PR TITLE
feat: add devcontainer for Codespaces support

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,33 @@
+{
+  "name": "proispro – Static Site Dev",
+  "image": "mcr.microsoft.com/devcontainers/base:ubuntu",
+
+  // Forward Live Server port so the preview auto-opens in the browser
+  "forwardPorts": [5500],
+  "portsAttributes": {
+    "5500": {
+      "label": "Live Server",
+      "onAutoForward": "openPreview"
+    }
+  },
+
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "ritwickdey.LiveServer",
+        "esbenp.prettier-vscode",
+        "Supabase.supabase-vscode",
+        "GitHub.vscode-pull-request-github"
+      ],
+      "settings": {
+        "liveServer.settings.port": 5500,
+        "liveServer.settings.donotShowInfoMsg": true,
+        "editor.formatOnSave": true,
+        "editor.defaultFormatter": "esbenp.prettier-vscode"
+      }
+    }
+  }
+
+  // No postCreateCommand — this is a zero-build-step static site.
+  // Open index.html then click "Go Live" in the status bar to start Live Server.
+}

--- a/.squad/agents/danny/history.md
+++ b/.squad/agents/danny/history.md
@@ -8,6 +8,14 @@
 
 ## Learnings
 
+### Codespaces devcontainer for zero-build static sites
+
+Set up `.devcontainer/devcontainer.json` for the proispro Alpine.js + Supabase static site (no build step). Key choices: `mcr.microsoft.com/devcontainers/base:ubuntu` image (lightweight, no Node toolchain overhead), Live Server extension on port 5500 for instant static preview, Supabase VS Code extension for schema/query inspection. No `postCreateCommand` — nothing to install. The copilot-setup-steps.yml in `.github/workflows/` is a CI workflow, not a devcontainer, so no conflict.
+
+**Trade-off noted:** Live Server port-forwarding in Codespaces requires the "Go Live" button click — not fully automatic. Alternative (serve via `npx serve`) would auto-start but adds a Node dependency. Kept zero-dependency approach consistent with project philosophy.
+
+---
+
 ### Static-first architecture validates for single-user tools
 
 The proispro disc golf inventory deliberately ships vanilla HTML/CSS/JS with zero build pipeline. This choice surfaces a key principle: **shipping simplicity beats framework cargo-cult**. The app weighs <50KB total and has zero external dependencies beyond browser APIs. Every build tool adds complexity without corresponding benefit at this scale.


### PR DESCRIPTION
## Summary

Adds .devcontainer/devcontainer.json to enable GitHub Codespaces for the proispro static site.

**Working as Danny (Lead / Architect)**

### What's included

- **Base image:** mcr.microsoft.com/devcontainers/base:ubuntu — minimal footprint, no Node toolchain overhead
- **Extensions pre-installed:** Live Server, Prettier, Supabase VS Code, GitHub PRs
- **Port 5500** forwarded and mapped to the preview pane (Live Server default)
- **No postCreateCommand** — zero-build static site, nothing to install

### Usage in Codespaces

1. Open the repo in a Codespace (Code → Codespaces → New)
2. Wait for container to build (~1 min first time)
3. Click **Go Live** in the VS Code status bar → instant preview at port 5500

### Trade-offs

Live Server requires one manual click to start — auto-serving via 
px serve was considered but rejected to keep zero-dependency principle intact (no Node runtime added). The existing copilot-setup-steps.yml is a CI workflow only — no conflict with the devcontainer.

---

Closes #6