### PR TITLE
feat: bag flight chart (speed vs turn scatter plot)

### DIFF
--- a/app.js
+++ b/app.js
@@ -236,6 +236,7 @@ function discApp() {
     discPickerSearch: '',
     bagHistory: [],
     showBagHistory: false,
+    showFlightChart: false,
     showPinModal: false,
     editingPinId: null,
     pinForm: { courseQuery: '', courseId: '', courseName: '', bagId: '' },
@@ -1721,6 +1722,45 @@ function discApp() {
         await this.loadBagHistory(bag.id);
       }
     },
+
+
+    // ── Flight Chart ──────────────────────────────────────────
+
+    getFlightChartData(bag) {
+      const discs = this.getDiscsForBag(bag);
+      return discs
+        .filter(d => d.speed != null && d.turn != null)
+        .map(d => ({
+          id: d.id,
+          name: d.name,
+          type: d.type || 'unknown',
+          speed: parseFloat(d.speed) || 0,
+          glide: parseFloat(d.glide) || 0,
+          turn: parseFloat(d.turn) || 0,
+          fade: parseFloat(d.fade) || 0,
+        }));
+    },
+
+    flightChartX(turn) {
+      // Turn range: -6 to +2 (map to 5%–95% of SVG width)
+      return ((turn + 6) / 8) * 90 + 5;
+    },
+
+    flightChartY(speed) {
+      // Speed range: 1–15 (inverted: high speed = top)
+      return (1 - (speed - 1) / 14) * 90 + 5;
+    },
+
+    flightChartColor(type) {
+      // Return OKLCH color matching disc type
+      const t = (type || '').toLowerCase();
+      if (t.includes('putter')) return 'oklch(65% 0.15 250)';       // blue
+      if (t.includes('mid')) return 'oklch(65% 0.15 145)';          // green
+      if (t.includes('fairway')) return 'oklch(65% 0.18 55)';       // orange
+      if (t.includes('distance') || t.includes('driver')) return 'oklch(65% 0.2 25)'; // red
+      return 'oklch(60% 0.1 280)';  // purple fallback
+    },
+
 
     // ── Course Pinning ───────────────────────────────────────
 

--- a/index.html
+++ b/index.html
@@ -480,6 +480,60 @@
                     </ul>
                   </div>
                 </div>
+
+                <!-- Flight Chart Toggle -->
+                <div class="flight-chart-section" x-show="getFlightChartData(bag).length > 0">
+                  <button class="btn btn-ghost btn-sm" @click="showFlightChart = !showFlightChart">
+                    <span x-text="showFlightChart ? '▼ Hide flight chart' : '📊 Flight chart'"></span>
+                  </button>
+                  <div x-show="showFlightChart" x-transition>
+                    <div class="flight-chart-container">
+                      <!-- Axis labels -->
+                      <div class="flight-chart-label-x">← Understable (Turn) Overstable →</div>
+                      <div class="flight-chart-label-y">Speed ↑</div>
+                      <svg class="flight-chart-svg" viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg"
+                           x-ref="flightChart">
+                        <!-- Grid lines -->
+                        <line x1="50" y1="5" x2="50" y2="95" stroke="var(--clr-border)" stroke-width="0.3" stroke-dasharray="1,1"/>
+                        <line x1="5" y1="50" x2="95" y2="50" stroke="var(--clr-border)" stroke-width="0.3" stroke-dasharray="1,1"/>
+                        <!-- Zero turn vertical line -->
+                        <line x1="80" y1="5" x2="80" y2="95" stroke="var(--clr-muted)" stroke-width="0.2" opacity="0.5"/>
+                        <!-- Disc dots -->
+                        <template x-for="d in getFlightChartData(bag)" :key="d.id">
+                          <g>
+                            <circle
+                              :cx="flightChartX(d.turn)"
+                              :cy="flightChartY(d.speed)"
+                              r="2.5"
+                              :fill="flightChartColor(d.type)"
+                              opacity="0.85"
+                              class="flight-chart-dot"
+                            >
+                              <title x-text="`${d.name} | ${d.speed}/${d.glide}/${d.turn}/${d.fade}`"></title>
+                            </circle>
+                            <text
+                              :x="flightChartX(d.turn)"
+                              :y="flightChartY(d.speed) - 3.5"
+                              text-anchor="middle"
+                              font-size="2.5"
+                              fill="var(--clr-text)"
+                              x-text="d.name.length > 8 ? d.name.slice(0,7)+'…' : d.name"
+                            ></text>
+                          </g>
+                        </template>
+                      </svg>
+                      <!-- Legend -->
+                      <div class="flight-chart-legend">
+                        <span class="legend-item"><span class="legend-dot" style="background:oklch(65% 0.15 250)"></span> Putter</span>
+                        <span class="legend-item"><span class="legend-dot" style="background:oklch(65% 0.15 145)"></span> Mid</span>
+                        <span class="legend-item"><span class="legend-dot" style="background:oklch(65% 0.18 55)"></span> Fairway</span>
+                        <span class="legend-item"><span class="legend-dot" style="background:oklch(65% 0.2 25)"></span> Driver</span>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+                  </div>
+                </div>
               </div>
             </div>
           </template>

--- a/styles.css
+++ b/styles.css
@@ -1681,3 +1681,92 @@ input.invalid, select.invalid { border-color: var(--clr-danger); }
   .wishlist-item { flex-direction: column; }
   .wishlist-item-actions { flex-direction: row; flex-wrap: wrap; align-items: center; }
 }
+
+/* ── Flight Chart ──────────────────────────────────────────────── */
+.flight-chart-section {
+  margin-top: 1rem;
+  padding-top: 1rem;
+  border-top: 1px solid var(--clr-border);
+}
+
+.flight-chart-container {
+  position: relative;
+  width: 100%;
+  max-width: 550px;
+  margin: 1rem auto 0;
+  padding: 1rem;
+  background: var(--clr-surface);
+  border: 1px solid var(--clr-border);
+  border-radius: var(--radius);
+}
+
+.flight-chart-svg {
+  width: 100%;
+  max-width: 500px;
+  aspect-ratio: 1;
+  display: block;
+  margin: 1rem auto;
+  background: var(--clr-surface2);
+  border-radius: var(--radius);
+}
+
+.flight-chart-dot {
+  cursor: pointer;
+  transition: transform 0.15s, opacity 0.15s;
+}
+
+.flight-chart-dot:hover {
+  transform: scale(1.4);
+  opacity: 1 !important;
+}
+
+.flight-chart-label-x,
+.flight-chart-label-y {
+  font-size: 0.72rem;
+  color: var(--clr-muted);
+  text-align: center;
+}
+
+.flight-chart-label-x {
+  margin-bottom: 0.5rem;
+}
+
+.flight-chart-label-y {
+  position: absolute;
+  top: 50%;
+  left: 0.3rem;
+  transform: translateY(-50%) rotate(-90deg);
+  transform-origin: center;
+}
+
+.flight-chart-legend {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.8rem;
+  justify-content: center;
+  margin-top: 0.8rem;
+  font-size: 0.8rem;
+}
+
+.legend-item {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+}
+
+.legend-dot {
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  display: inline-block;
+}
+
+@media (max-width: 768px) {
+  .flight-chart-container {
+    padding: 0.75rem;
+  }
+  .flight-chart-svg {
+    max-width: 100%;
+  }
+}
+


### PR DESCRIPTION
## What

Adds a visual flight chart to the bag detail view.

- Pure SVG, no external library
- X: Turn value (understable ← → overstable)
- Y: Speed (1–15)
- Color-coded by disc type (putter/mid/fairway/driver)
- Hover tooltip with full flight numbers

Closes #58

Working as Rusty (Frontend Dev)