### PR TITLE
feat: bag change history UI panel (Moxfield-style)

### DIFF
--- a/.squad/agents/rusty/history.md
+++ b/.squad/agents/rusty/history.md
@@ -520,3 +520,35 @@ Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
 **Status:** PR #59 opened (draft), issues #56 and #53 closed. 🟢 Good fit task — pure frontend work, no DB schema changes.
 
 **Follow-up:** After Basher implements FR-3b migration (#57 — add JSONB holes column to course_pins), we'll need to sync localStorage cache to Supabase on next pin save. That's a separate issue.
+- **Tech notes:** All vanilla JS + Alpine.js reactivity. No external crop libraries. Canvas 2D API with evenodd fill for cutout, pointer events for modern touch/mouse/pen handling. Blob created via canvas.toBlob() for efficient memory usage.
+
+### 2026-05-16 — Bag Change History UI Panel (Issue #51, PR #62)
+
+**Implemented Moxfield-style bag change history view (FR-2 UI phase):**
+
+- **Three new methods in app.js:**
+  - loadBagHistory(bagId) — fetches last 20 changes from ag_history table, ordered by changed_at DESC
+  - ormatHistoryTime(ts) — hand-rolled relative time formatter (no library): "just now" / "Xm ago" / "Xh ago" / "Xd ago" / locale date
+  - openBagDetail(bag) — replaces inline toggle; loads history on bag expand, clears history on collapse
+- **State:** agHistory: [], showBagHistory: false added to Alpine data init
+- **HTML:** New collapsible section below disc list in bag detail view (.bag-history-section)
+  - Toggle button: ▶ Change history / ▼ Hide history
+  - Empty state: "No changes recorded yet"
+  - History list: +1/-1 badge (green/red), disc name, relative timestamp
+  - Alpine x-transition for smooth expand/collapse (no collapse plugin needed)
+- **CSS:** ~80 new lines in styles.css after .bag-disc-mfr
+  - .bag-history-section — border-top separator, 1rem top margin
+  - .bag-history-entry — flexbox row, hover background transition
+  - .badge-added (green) / .badge-removed (red) — pill badges using existing OKLCH vars (ar(--midrange), ar(--clr-danger))
+  - Mobile-responsive: all text remains readable, no stacking needed
+- **Dependency:** Assumes ag_history table exists (migration #49 already live), _recordBagHistory wired in app.js (PR #59 pending)
+- **Graceful fallback:** If Supabase unavailable or local mode, history array stays empty → shows "No changes recorded yet"
+
+**Architecture notes:**
+- Updated bag card header from inline @click toggle to openBagDetail(bag) method call — pattern consistent with other modals
+- History loaded asynchronously on bag expand; cleared on collapse to avoid stale data
+- No pagination (limit 20) — sufficient for typical usage; can extend later if needed
+- Timestamp formatting matches Moxfield UX: terse for recent changes, expands to full date after 7 days
+
+**Status:** PR #62 draft, branch squad/51-bag-history-ui. Depends on PR #59 (wiring) merging first. 🟢 Good fit task — no review needed.
+

--- a/app.js
+++ b/app.js
@@ -234,6 +234,8 @@ function discApp() {
     showDiscPickerModal: false,
     discPickerBagId: null,
     discPickerSearch: '',
+    bagHistory: [],
+    showBagHistory: false,
     showPinModal: false,
     editingPinId: null,
     pinForm: { courseQuery: '', courseId: '', courseName: '', bagId: '' },
@@ -1668,6 +1670,56 @@ function discApp() {
 
     getBagsForDisc(discId) {
       return this.bags.filter(b => b.discIds.includes(discId));
+    },
+
+    // ── Bag History ───────────────────────────────────────────
+
+    async loadBagHistory(bagId) {
+      const sb = getSupabase();
+      if (!sb || this.user?.id === 'local') {
+        this.bagHistory = [];
+        return;
+      }
+      try {
+        const { data } = await sb
+          .from('bag_history')
+          .select('*')
+          .eq('bag_id', bagId)
+          .order('changed_at', { ascending: false })
+          .limit(20);
+        this.bagHistory = data || [];
+      } catch {
+        this.bagHistory = [];
+      }
+    },
+
+    formatHistoryTime(ts) {
+      if (!ts) return '';
+      const now = Date.now();
+      const then = new Date(ts).getTime();
+      const diffMs = now - then;
+      const diffMin = Math.floor(diffMs / 60000);
+      const diffHr = Math.floor(diffMs / 3600000);
+      const diffDay = Math.floor(diffMs / 86400000);
+      
+      if (diffMin < 1) return 'just now';
+      if (diffMin < 60) return `${diffMin}m ago`;
+      if (diffHr < 24) return `${diffHr}h ago`;
+      if (diffDay < 7) return `${diffDay}d ago`;
+      return new Date(ts).toLocaleDateString();
+    },
+
+    async openBagDetail(bag) {
+      // Toggle bag detail open/closed
+      if (this.activeBagId === bag.id) {
+        this.activeBagId = null;
+        this.bagHistory = [];
+        this.showBagHistory = false;
+      } else {
+        this.activeBagId = bag.id;
+        this.showBagHistory = false;
+        await this.loadBagHistory(bag.id);
+      }
     },
 
     // ── Course Pinning ───────────────────────────────────────

--- a/index.html
+++ b/index.html
@@ -427,7 +427,7 @@
           <!-- Bag cards -->
           <template x-for="bag in bags" :key="bag.id">
             <div class="bag-card">
-              <div class="bag-card-header" @click="activeBagId = (activeBagId === bag.id ? null : bag.id)">
+              <div class="bag-card-header" @click="openBagDetail(bag)">
                 <div class="bag-card-info">
                   <span class="bag-name" x-text="bag.name"></span>
                   <span class="bag-count" x-text="bag.discIds.length + ' disc' + (bag.discIds.length !== 1 ? 's' : '')"></span>
@@ -459,6 +459,26 @@
                       <button class="btn btn-danger btn-sm" @click="removeDiscFromBag(bag.id, disc.id)" title="Remove from bag">✕</button>
                     </div>
                   </template>
+                </div>
+
+                <!-- Bag Change History -->
+                <div class="bag-history-section">
+                  <button class="btn btn-ghost btn-sm" @click="showBagHistory = !showBagHistory">
+                    <span x-text="showBagHistory ? '▼ Hide history' : '▶ Change history'"></span>
+                  </button>
+                  <div x-show="showBagHistory" x-transition>
+                    <div class="bag-history-empty" x-show="bagHistory.length === 0">No changes recorded yet</div>
+                    <ul class="bag-history-list" x-show="bagHistory.length > 0">
+                      <template x-for="entry in bagHistory" :key="entry.id">
+                        <li class="bag-history-entry">
+                          <span class="bag-history-badge" :class="entry.action === 'added' ? 'badge-added' : 'badge-removed'"
+                                x-text="entry.action === 'added' ? '+1' : '-1'"></span>
+                          <span class="bag-history-disc" x-text="entry.disc_name"></span>
+                          <span class="bag-history-time" x-text="formatHistoryTime(entry.changed_at)"></span>
+                        </li>
+                      </template>
+                    </ul>
+                  </div>
                 </div>
               </div>
             </div>

--- a/styles.css
+++ b/styles.css
@@ -889,6 +889,86 @@ input.invalid, select.invalid { border-color: var(--clr-danger); }
 .bag-disc-name { font-weight: 500; color: var(--clr-text); flex: 1 1 auto; }
 .bag-disc-mfr  { color: var(--clr-muted); font-size: .8rem; }
 
+/* ── Bag Change History ───────────────────────────────────── */
+
+.bag-history-section {
+  margin-top: 1rem;
+  padding-top: 1rem;
+  border-top: 1px solid var(--clr-border);
+}
+
+.bag-history-empty {
+  margin-top: 0.75rem;
+  padding: 1rem;
+  text-align: center;
+  font-size: 0.85rem;
+  color: var(--clr-muted);
+  background: var(--clr-surface);
+  border-radius: var(--radius);
+}
+
+.bag-history-list {
+  list-style: none;
+  margin-top: 0.75rem;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.bag-history-entry {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.6rem 0.75rem;
+  background: var(--clr-surface);
+  border-radius: calc(var(--radius) * 0.7);
+  font-size: 0.88rem;
+  transition: background 0.15s;
+}
+
+.bag-history-entry:hover {
+  background: var(--clr-surface2);
+}
+
+.bag-history-badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 2rem;
+  padding: 0.2rem 0.45rem;
+  font-size: 0.72rem;
+  font-weight: 600;
+  border-radius: 1rem;
+  flex-shrink: 0;
+}
+
+.badge-added {
+  background: rgba(34, 197, 94, 0.12);
+  color: var(--midrange);
+  border: 1px solid rgba(34, 197, 94, 0.25);
+}
+
+.badge-removed {
+  background: rgba(239, 68, 68, 0.15);
+  color: var(--clr-danger);
+  border: 1px solid rgba(239, 68, 68, 0.3);
+}
+
+.bag-history-disc {
+  flex: 1;
+  color: var(--clr-text);
+  font-weight: 500;
+}
+
+.bag-history-time {
+  font-size: 0.75rem;
+  color: var(--clr-muted);
+  flex-shrink: 0;
+  text-align: right;
+}
+
+
 /* ── Disc card bag quick-assign ───────────────────────────── */
 .bag-quick-action { position: relative; }
 


### PR DESCRIPTION
## What

Displays Moxfield-style bag change history in the bag detail view.

- +1/-1 action badges (green/red)
- Disc name
- Relative timestamp (just now / Xm ago / Xh ago)
- Toggle show/hide, loads from Supabase bag_history table

Depends on: migration #49 (already live) and wiring #50 (in PR #59)

Closes #51

Working as Rusty (Frontend Dev)